### PR TITLE
Fix validate-lore script

### DIFF
--- a/scripts/validate-lore.ts
+++ b/scripts/validate-lore.ts
@@ -36,6 +36,6 @@ const LORE_DIR = path.resolve(process.cwd(), 'public/data/first-flame');
     console.error('\nAborting build: lore validation failed.\n');
     process.exit(1);
   } else {
-    console.log('All lore files valid ✔︎');
+  console.log('All lore files valid \u2714');
   }
 })();


### PR DESCRIPTION
## Summary
- update `scripts/validate-lore.ts` so the success message line is valid TypeScript

## Testing
- `pnpm install` *(failed: network unreachable)*
- `pnpm run validate:lore` *(failed: ts-node not found)*