### PR TITLE
Fix validate-lore script

### DIFF
--- a/scripts/validate-lore.ts
+++ b/scripts/validate-lore.ts
@@ -36,6 +36,6 @@ const LORE_DIR = path.resolve(process.cwd(), 'public/data/first-flame');
     console.error('\nAborting build: lore validation failed.\n');
     process.exit(1);
   } else {
-    console.log('All lore files valid ✔︎');
+    console.log('All lore files valid ✔');
   }
 })();


### PR DESCRIPTION
## Summary
- remove invalid bytes from console.log line in `scripts/validate-lore.ts`

## Testing
- `pnpm run validate:lore` *(fails: ts-node not found)*