### PR TITLE
Sync DAYDEF constants across runtimes

### DIFF
--- a/modal_app/constants.py
+++ b/modal_app/constants.py
@@ -1,0 +1,4 @@
+from typing import Final
+
+DAYDEF_BUCKET: Final[str] = "asrayaospublicbucket"
+DAYDEF_PREFIX: Final[str] = "5-day/"

--- a/modal_app/update_flame_status.py
+++ b/modal_app/update_flame_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json, logging, os, time
 from typing import Any, Final
+from .constants import DAYDEF_BUCKET, DAYDEF_PREFIX
 
 import modal
 from supabase import create_client
@@ -10,7 +11,6 @@ from supabase.client import Client                            # type-hints only
 from postgrest.exceptions import APIError                     # ← catch Rpc errors
 
 # ─────── constants ───────
-DAYDEF_BUCKET:     Final[str] = "asrayaospublicbucket"
 FIRST_FLAME_SLUG:  Final[str] = "first_flame"
 BROADCAST_CHANNEL: Final[str] = "flame_status"
 RITUAL_SCHEMA:     Final[str] = "ritual"
@@ -49,7 +49,7 @@ def _ensure_quest(ritual: Client) -> str:
 
 def _load_daydef(sb: Client, *, day: int = 1) -> Any:
     """Download `day-<n>.json` from Storage and sanity-check it."""
-    blob = sb.storage.from_(DAYDEF_BUCKET).download(f"day-{day}.json")
+    blob = sb.storage.from_(DAYDEF_BUCKET).download(f"{DAYDEF_PREFIX}day-{day}.json")
     data = json.loads(blob.decode())
     if not data.get("prompts"):
         raise ValueError("Day-definition JSON missing ‘prompts’ array")

--- a/supabase/functions/_shared/5dayquest/flame-data-loader.ts
+++ b/supabase/functions/_shared/5dayquest/flame-data-loader.ts
@@ -8,10 +8,10 @@ import type {
   RitualDayNumber,
   FlameDayDefinition,
 } from './FirstFlame.ts';
+import { DAYDEF_PREFIX } from './ritual.constants.ts';
 
 /*────────────────────────  Config  ────────────────────────*/
-const MAX_CACHE_ENTRIES = 7;      // 5 ritual days + 2 spare
-const DAYDEF_PREFIX     = './5-day/';   // 👈 NEW – sub-folder for day defs
+const MAX_CACHE_ENTRIES = 7; // 5 ritual days + 2 spare
 
 /*───────────────────────  State  ──────────────────────────*/
 const dataCache   = new Map<RitualDayNumber, Readonly<FlameDayDefinition>>();

--- a/supabase/functions/_shared/5dayquest/ritual.constants.ts
+++ b/supabase/functions/_shared/5dayquest/ritual.constants.ts
@@ -4,6 +4,11 @@
 
 export type RitualDayNumber = 1 | 2 | 3 | 4 | 5;
 
+/** Storage folder prefix for ritual day-definition JSON files */
+export const DAYDEF_PREFIX = '5-day/' as const;
+/** Public Supabase bucket containing the day-definition files */
+export const DAYDEF_BUCKET = 'asrayaospublicbucket' as const;
+
 /* stages – individual exports for tree-shaking */
 export const STAGE_SPARK     = 'spark'     as const;
 export const STAGE_SYMBOL    = 'symbol'    as const;

--- a/supabase/functions/get-flame-status/index.ts
+++ b/supabase/functions/get-flame-status/index.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { DAYDEF_BUCKET, DAYDEF_PREFIX } from '../_shared/5dayquest/ritual.constants.ts';
 
 /* ──────────────── ENV ──────────────── */
 const SB_URL  = Deno.env.get('SUPABASE_URL')!;
@@ -8,10 +9,8 @@ const SB_ANON = Deno.env.get('SUPABASE_ANON_KEY')!;
 const SB_SVC  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
 /* ─────────────── CONFIG ────────────── */
-const STALE_MS       = 60_000;                   // 1-min freshness window
-const DAYDEF_BUCKET  = 'asrayaospublicbucket';   // ← matches Modal worker
-const DAYDEF_PREFIX  = '5-day/';                 // ← NEW (keep in sync!)
-const DAY_1_PATH     = `${DAYDEF_PREFIX}day-1.json`;
+const STALE_MS = 60_000; // 1-min freshness window
+const DAY_1_PATH = `${DAYDEF_PREFIX}day-1.json`;
 
 /* ─────────────── CORS ──────────────── */
 const cors = {


### PR DESCRIPTION
## Summary
- centralize DAYDEF_PREFIX and bucket in `ritual.constants.ts`
- import constants in get-flame-status edge function
- share prefix constant with flame-data-loader
- move Modal worker constants to a shared module

## Testing
- `pnpm run lint` *(fails: next not found)*
- `pnpm run typecheck` *(fails: tsc errors; modules missing)*
