### PR TITLE
Implement flame broadcast listener

### DIFF
--- a/src/features/hub/components/ActiveConversationPanel.tsx
+++ b/src/features/hub/components/ActiveConversationPanel.tsx
@@ -23,6 +23,7 @@ import { ChatInputBar } from '../../chat/components/ChatInputBar';
 import { MessageRenderer, CombinedContentItem } from '../../chat/components/messages/MessageRenderer';
 import { TypingIndicator } from '../../chat/components/TypingIndicator';
 import { OracleOrb } from './oracleOrb';
+import { useFlameBroadcast } from '@/hooks/useFlameBroadcast';
 
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 
@@ -79,6 +80,8 @@ const ActiveConversationPanelComponent: React.FC<ActiveConversationPanelProps> =
   );
 
   const queryClient = useQueryClient();
+  // Listen for realtime flame status updates
+  useFlameBroadcast();
 
   const activeConversation = useMemo((): Quest | null =>
     (quests ?? []).find((c) => c.id === activeQuestId) || null

--- a/src/hooks/useFlameBroadcast.ts
+++ b/src/hooks/useFlameBroadcast.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { gsap } from '@/lib/gsapSetup';
+import { createClient } from '@/lib/supabase_client/client';
+import { FLAME_STATUS_QUERY_KEY, QUESTS_QUERY_KEY } from '@/lib/api/quests';
+
+/**
+ * Subscribes to the `flame_status` realtime channel and reacts to
+ * `ready` events by invalidating cached queries and triggering a
+ * visual pulse on the OracleOrb.
+ */
+export function useFlameBroadcast(): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const supabase = createClient();
+    const channel = supabase.channel('flame_status');
+
+    const handleReady = () => {
+      queryClient.invalidateQueries({ queryKey: FLAME_STATUS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: QUESTS_QUERY_KEY });
+
+      const orb = document.querySelector<HTMLElement>('[data-testid="oracle-orb"]');
+      if (orb) {
+        gsap.fromTo(
+          orb,
+          { boxShadow: '0 0 30px rgba(168, 85, 247, 0.6)' },
+          {
+            boxShadow: '0 0 60px rgba(168, 85, 247, 1)',
+            duration: 0.5,
+            yoyo: true,
+            repeat: 1,
+            ease: 'power2.out',
+          }
+        );
+      }
+    };
+
+    channel.on('broadcast', { event: 'ready' }, handleReady);
+    channel.subscribe();
+
+    return () => {
+      supabase.removeChannel(channel).catch(() => undefined);
+    };
+  }, [queryClient]);
+}

--- a/src/lib/api/quests.ts
+++ b/src/lib/api/quests.ts
@@ -339,6 +339,8 @@ export async function submitImprint(
 
 /** Query key for fetching flame status. */
 export const FLAME_STATUS_QUERY_KEY = ['flame-status'] as const;
+/** Query key for the user's quest list. */
+export const QUESTS_QUERY_KEY = ['list-quests'] as const;
 
 /**
  * Default options for `useQuery` hook when fetching flame status.


### PR DESCRIPTION
## Summary
- define `QUESTS_QUERY_KEY`
- add `useFlameBroadcast` hook to listen on `flame_status` channel
- trigger query invalidations and pulse OracleOrb on ready events
- use the new hook in `ActiveConversationPanel`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: "NotificationItem.ts" etc.)*