### PR TITLE
Fix quest list undefined.map bug

### DIFF
--- a/src/features/hub/components/leftpanel/QuestListView.tsx
+++ b/src/features/hub/components/leftpanel/QuestListView.tsx
@@ -394,7 +394,7 @@ import React, {
             ) : (
               // --- Static List ---
               <div className="p-1 space-y-px">
-                {listItemData.map((questItem, index) => {
+                {listItemData?.map((questItem, index) => {
                   const isActive = activeQuestId === questItem.id;
                   const isFocusedByKeyboard = activeDescendantIndex === index; // For visual keyboard focus indication
                   const questListItemId = `${panelId}-quest-item-${questItem.id}`;

--- a/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
+++ b/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
@@ -276,6 +276,8 @@ export const useUnifiedChatPanelData = ({
   // This `isPendingSearch` indicates if the displayed list might be stale due to active search input.
   const isPendingSearch = listQ.isFetching && searchInput.trim().toLowerCase() !== deferredQuery; // .toLowerCase() added by diff, searchInput.trim() was searchInput.trim().toLowerCase() in diff, base was searchInput.trim()
 
+  const listItemData = filteredQuests ?? [];
+
 
   /* ---------------- Return API ---------------- */
   return {
@@ -285,7 +287,7 @@ export const useUnifiedChatPanelData = ({
     isPendingSearch,
 
     quests, // All available quests, sorted
-    listItemData: filteredQuests as QuestForListItemAugmented[], // Cast added by diff
+    listItemData: listItemData as QuestForListItemAugmented[],
 
     firstFlameQuest: quests.find((q) => q.isFirstFlameRitual),
     activeQuestId,

--- a/src/tests/QuestListView.test.tsx
+++ b/src/tests/QuestListView.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QuestListView } from '@/features/hub/components/leftpanel/QuestListView';
+
+const baseProps = {
+  panelId: 'test-panel',
+  activeQuestId: null,
+  handleSelectQuest: () => {},
+  handleSearchChange: () => {},
+  searchQuery: '',
+  isLoadingBackground: false,
+  isPendingSearch: false,
+  isVtEnabled: false,
+  shouldVirtualize: false,
+  quests: [],
+  onSelectFirstFlameFromHeader: () => {},
+  handleCreateNewQuest: () => {},
+  handlePinQuest: () => {},
+  questsTitleRef: { current: null } as React.RefObject<HTMLHeadingElement>,
+  searchBarContainerRef: { current: null } as React.RefObject<HTMLDivElement>,
+  headerFirstFlameButtonRef: { current: null } as React.RefObject<HTMLButtonElement>,
+};
+
+describe('QuestListView', () => {
+  it('renders empty state when listItemData is empty', () => {
+    render(<QuestListView {...baseProps} listItemData={[]} />);
+    expect(
+      screen.getByText('No quests available. Start a new one!')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent undefined map calls by defaulting listItemData to []
- guard QuestListView map with optional chaining
- add test covering empty quest list state

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm typecheck` *(fails: missing node_modules)*
- `pnpm dev` *(fails: next not found)*
- `npx vitest run` *(fails: cannot reach npm registry)*