### PR TITLE
Fix GSAP cleanup in HeroIntroScreen

### DIFF
--- a/src/features/hub/components/leftpanel/HeroIntroScreen.tsx
+++ b/src/features/hub/components/leftpanel/HeroIntroScreen.tsx
@@ -97,6 +97,7 @@ const HeroIntroScreenComp: React.FC<Props> = (props) => {
       btn.removeEventListener('mouseleave', leave);
       btn.removeEventListener('focus', enter);
       btn.removeEventListener('blur',  leave);
+      tl.revert();
       tl.kill();
     };
   }, [prefersReduced, heroButtonRef]);


### PR DESCRIPTION
## Summary
- revert the hero button hover timeline on unmount to avoid timeline leaks

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm lint` *(fails: next not found)*
- `pnpm typecheck` *(fails with TS errors)*
- `pnpm dev` *(fails: next not found)*