### PR TITLE
Fix quest list item default

### DIFF
--- a/src/features/hub/components/leftpanel/QuestListView.tsx
+++ b/src/features/hub/components/leftpanel/QuestListView.tsx
@@ -135,7 +135,7 @@ import { shallow } from 'zustand/shallow';
   // === Main List View Component ===
   const QuestListViewComponent: React.FC<QuestListViewProps> = ({
     panelId,
-    listItemData,
+    listItemData = [],
     activeQuestId,
     handleSelectQuest,
     handleSearchChange,


### PR DESCRIPTION
## Summary
- avoid undefined.map in `QuestListView` by defaulting `listItemData` prop

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm typecheck` *(fails: missing node modules)*