### PR TITLE
Handle uncaught errors in withCors wrapper

### DIFF
--- a/supabase/functions/_shared/withCors.ts
+++ b/supabase/functions/_shared/withCors.ts
@@ -32,13 +32,25 @@ export function withCors(
     }
 
     // 2️⃣  Execute the actual business logic
-    const res = await handler(req);
+    try {
+      const res = await handler(req);
 
-    // 3️⃣  Add (or overwrite) CORS headers on the way out
-    for (const [key, value] of Object.entries(corsHeaders)) {
-      res.headers.set(key, value as string);
+      // 3️⃣  Add (or overwrite) CORS headers on the way out
+      for (const [key, value] of Object.entries(corsHeaders)) {
+        res.headers.set(key, value as string);
+      }
+
+      return res;
+    } catch (err) {
+      console.error('[withCors] uncaught error', err);
+      const res = new Response(
+        JSON.stringify({ error: 'SERVER_ERROR' }),
+        { status: 500 },
+      );
+      for (const [k, v] of Object.entries(corsHeaders)) {
+        res.headers.set(k, v as string);
+      }
+      return res;
     }
-
-    return res;
   };
 }


### PR DESCRIPTION
## Summary
- catch unexpected errors in the `withCors` middleware
- return `SERVER_ERROR` JSON with CORS headers on failure

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm typecheck` *(fails: missing dependencies)*
- `pnpm dev` *(fails: `next` not found)*