### PR TITLE
Fix get-flame-status body read

### DIFF
--- a/supabase/functions/get-flame-status/index.ts
+++ b/supabase/functions/get-flame-status/index.ts
@@ -43,7 +43,13 @@ Deno.serve(
       if (req.method !== 'GET' && req.method !== 'POST')
         return json({ error: 'METHOD_NOT_ALLOWED' }, 405);
 
-      if (req.method === 'POST') await req.json();
+      if (req.method === 'POST') {
+        try {
+          await req.json();
+        } catch (err) {
+          console.error('[get-flame-status] failed to parse body', err);
+        }
+      }
 
       /* Auth guard */
       const jwt = req.headers.get('Authorization') ?? '';


### PR DESCRIPTION
## Summary
- guard against missing POST bodies when parsing

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm typecheck` *(fails to compile)*