### PR TITLE
edge: add helper for first flame progress

### DIFF
--- a/supabase/functions/_shared/db/firstFlame.ts
+++ b/supabase/functions/_shared/db/firstFlame.ts
@@ -98,3 +98,33 @@ export async function getOrCreateFirstFlame(
   // console.debug(`[shared/db/firstFlame] Successfully inserted quest for slug '${FIRST_FLAME_SLUG}'. ID: ${newQuest.id}`);
   return newQuest;
 }
+
+/**
+ * getOrCreateFirstFlameProgress
+ * -----------------------------------------------------
+ * Ensure a flame_progress row exists for the given user.
+ * Inserts `current_day_target = 1` if missing. Caller must
+ * provide the quest id (typically from getOrCreateFirstFlame).
+ */
+export async function getOrCreateFirstFlameProgress(
+  admin: SupabaseClient,
+  userId: string,
+  questId: string,
+): Promise<void> {
+  const { error } = await admin
+    .from('flame_progress')
+    .upsert(
+      {
+        quest_id: questId,
+        user_id: userId,
+        current_day_target: 1,
+        is_quest_complete: false,
+      },
+      { onConflict: 'quest_id,user_id', ignoreDuplicates: true },
+    );
+
+  if (error) {
+    console.error('[shared/db/firstFlame] flame_progress upsert error', error);
+    throw error;
+  }
+}

--- a/supabase/functions/list-quests/index.ts
+++ b/supabase/functions/list-quests/index.ts
@@ -14,8 +14,11 @@ import {
   captureError,
   flushSentryEvents,
 }                             from '../_shared/sentry.ts'
-import { getOrCreateFirstFlame, type QuestRow as MinQuestRow }
-                             from '../_shared/db/firstFlame.ts'
+import {
+  getOrCreateFirstFlame,
+  getOrCreateFirstFlameProgress,
+  type QuestRow as MinQuestRow,
+}                             from '../_shared/db/firstFlame.ts'
 import { toISO }              from '../_shared/types/index.ts'
 import {
   FIRST_FLAME_SLUG,
@@ -140,6 +143,12 @@ Deno.serve(async (req) => {
       { onConflict: 'quest_id,user_id', ignoreDuplicates: true },
     )
     if (upsertErr) console.error(`[${FN}] quest_participants upsert error`, upsertErr)
+
+    try {
+      await getOrCreateFirstFlameProgress(sbAdmin, user.id, ff.id)
+    } catch (pe) {
+      console.error(`[${FN}] flame_progress upsert error`, pe)
+    }
 
     /*── Fetch quests visible to the caller ───────────────────────*/
     const { data, error: fetchErr } = await sbUser


### PR DESCRIPTION
## Summary
- create getOrCreateFirstFlameProgress for flame_progress upserts
- insert progress row when listing quests

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*