### PR TITLE
edge: log get-flame-status startup

### DIFF
--- a/supabase/functions/get-flame-status/index.ts
+++ b/supabase/functions/get-flame-status/index.ts
@@ -67,6 +67,10 @@ Deno.serve(
         db  : { schema: 'ritual' },
       });
 
+      const { data: { user }, error: userErr } = await sbUser.auth.getUser();
+      if (userErr) console.error('[get-flame-status] auth.getUser error', userErr);
+      console.info('[EF:get-flame-status] start', { user_id: user?.id });
+
     /* 1️⃣  Get progress row (cheap) */
     const {
       data: progress,
@@ -119,8 +123,6 @@ Deno.serve(
     }
 
     /* ───── STALE PATH ───── */
-    const { data: { user }, error: userErr } = await sbUser.auth.getUser();
-    if (userErr) console.error('[get-flame-status] auth.getUser error', userErr);
 
     try {
       const { error: invokeErr } =


### PR DESCRIPTION
## Summary
- log start of the `get-flame-status` edge function

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm typecheck` *(fails: node_modules missing)*