### PR TITLE
Fix null checks for quest data

### DIFF
--- a/src/features/hub/components/leftpanel/HeroIntroScreen.tsx
+++ b/src/features/hub/components/leftpanel/HeroIntroScreen.tsx
@@ -65,6 +65,8 @@ const HeroIntroScreenComp: React.FC<Props> = (props) => {
     questsAvailable,
   } = props;
 
+  const safeFirstFlameQuest = firstFlameQuest ?? null;
+
   const router         = useRouter();
   const containerRef   = useRef<HTMLDivElement>(null);
   const prefersReduced = useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -158,7 +160,7 @@ const HeroIntroScreenComp: React.FC<Props> = (props) => {
     }
 
     // ––– at least one quest exists –––
-    if (isInitialLoadComplete && questsAvailable && firstFlameQuest) {
+    if (isInitialLoadComplete && questsAvailable && safeFirstFlameQuest) {
       return (
         <>
           <h3 className="text-xl font-semibold">Your path awaits</h3>
@@ -166,7 +168,7 @@ const HeroIntroScreenComp: React.FC<Props> = (props) => {
             Continue your adventure or embark on the First Flame.
           </p>
           <Button ref={heroButtonRef} size="lg" onClick={handleBeginExisting}>
-            {firstFlameQuest.name ?? 'Begin First Flame'}
+            {safeFirstFlameQuest.name ?? 'Begin First Flame'}
           </Button>
         </>
       );

--- a/src/features/hub/components/leftpanel/QuestListView.tsx
+++ b/src/features/hub/components/leftpanel/QuestListView.tsx
@@ -153,6 +153,7 @@ import { shallow } from 'zustand/shallow';
     headerFirstFlameButtonRef,
     headerNewQuestButtonRef,
   }) => {
+    const questsArray = quests ?? [];
     const listContainerRef = useRef<HTMLDivElement>(null); // For the listbox container
     const fixedListRef = useRef<FixedSizeList>(null); // For react-window API
 
@@ -163,9 +164,10 @@ import { shallow } from 'zustand/shallow';
     const hasMounted = useRef(false); // To prevent effects on initial mount if not desired
   
     const firstFlameQuest = useMemo(
-      () => quests.find((q) => q.slug === FIRST_FLAME_RITUAL_SLUG),
-      [quests]
+      () => questsArray.find((q) => q.slug === FIRST_FLAME_RITUAL_SLUG),
+      [questsArray]
     );
+    const safeFirstFlameQuest = firstFlameQuest ?? null;
   
     // --- ARIA Active Descendant ID ---
     const activeDescendantId = useMemo(() => {
@@ -294,14 +296,14 @@ import { shallow } from 'zustand/shallow';
               Quests
             </h2>
             <div className="flex items-center space-x-2">
-              {firstFlameQuest && (
+              {safeFirstFlameQuest && (
                 <Button
                   ref={headerFirstFlameButtonRef}
                   variant="ghost"
                   size="sm"
                   onClick={onSelectFirstFlameFromHeader}
-                  aria-label={`Begin ${firstFlameQuest.name}`}
-                  title={`Begin ${firstFlameQuest.name}`}
+                  aria-label={`Begin ${safeFirstFlameQuest.name}`}
+                  title={`Begin ${safeFirstFlameQuest.name}`}
                   className="text-primary hover:text-primary/90"
                   data-testid="header-first-flame-button"
                 >

--- a/src/features/hub/components/leftpanel/UnifiedChatListPanel.tsx
+++ b/src/features/hub/components/leftpanel/UnifiedChatListPanel.tsx
@@ -99,6 +99,8 @@ function UnifiedChatListPanelImpl({
     initialQuestSlugToSelect,
   });
 
+  const safeFirstFlameQuest = firstFlameQuest ?? null;
+
   /* ----------------------- View‑Transition Flag ------------------------ */
   const { enableViewTransition: devToolsVTEnabled } = useDevToolsStore(
     s => ({ enableViewTransition: s.enableViewTransition }),
@@ -119,12 +121,12 @@ function UnifiedChatListPanelImpl({
 
   /* --------------------------- Handlers -------------------------------- */
   const handleSelectFirstFlameFromHeader = useCallback(() => {
-    if (firstFlameQuest) handleSelectQuest(firstFlameQuest.id);
-  }, [firstFlameQuest, handleSelectQuest]);
+    if (safeFirstFlameQuest) handleSelectQuest(safeFirstFlameQuest.id);
+  }, [safeFirstFlameQuest, handleSelectQuest]);
 
   const handleSelectFirstFlameFromHero = useCallback(() => {
-    firstFlameQuest ? handleSelectQuest(firstFlameQuest.id) : handleCreateNewQuest();
-  }, [firstFlameQuest, handleSelectQuest, handleCreateNewQuest]);
+    safeFirstFlameQuest ? handleSelectQuest(safeFirstFlameQuest.id) : handleCreateNewQuest();
+  }, [safeFirstFlameQuest, handleSelectQuest, handleCreateNewQuest]);
 
   /* ------------------------ Early‑return Error ------------------------- */
   if (uiPhase === UIPanelPhase.ERROR) {
@@ -162,7 +164,7 @@ function UnifiedChatListPanelImpl({
             uiPhase={uiPhase}
             isLoadingInitial={isLoadingInitial}
             errorDisplay={errorDisplay}
-            firstFlameQuest={firstFlameQuest}
+            firstFlameQuest={safeFirstFlameQuest}
             isInitialLoadComplete={isInitialLoadComplete}
             questsAvailable={quests.length > 0}
             onSelectFirstFlame={handleSelectFirstFlameFromHero}


### PR DESCRIPTION
## Summary
- guard against undefined quests in `useUnifiedChatPanelData`
- use `questsArray` helper in quest list components
- handle undefined `firstFlameQuest` in UI components

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: many TS errors)*