### PR TITLE
Add shared storage decode helper

### DIFF
--- a/supabase/functions/_shared/utils.ts
+++ b/supabase/functions/_shared/utils.ts
@@ -1,0 +1,12 @@
+export async function decodeStorage(data: unknown): Promise<string> {
+  if (data instanceof Uint8Array) {
+    return new TextDecoder().decode(data);
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+  if (data instanceof Blob) {
+    return data.text();
+  }
+  throw new TypeError('Unsupported storage data type');
+}


### PR DESCRIPTION
## Summary
- add a shared `decodeStorage` helper for edge functions

## Testing
- `npm run lint` *(fails: next not found)*