### PR TITLE
Fix realtime-broadcast timeout handling

### DIFF
--- a/supabase/functions/realtime-broadcast/index.ts
+++ b/supabase/functions/realtime-broadcast/index.ts
@@ -1,17 +1,32 @@
 // deno-lint-ignore-file
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 const sb = createClient(
   Deno.env.get('SUPABASE_URL')!,
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
 );
 
 Deno.serve(async (req) => {
-  const { channel, event, payload } = await req.json();
+  const { channel: channelName, event, payload } = await req.json();
 
-  await sb.postgrest.rpc('broadcast', { channel, event, payload }).throwOnError();
+  const channel = sb.channel(channelName);
+  const sendPromise = channel.send({ type: 'broadcast', event, payload });
+  const result = (await Promise.race([sendPromise, delay(5000)])) as
+    | { error: { message: string } | null }
+    | undefined;
 
-  return new Response(JSON.stringify({ ok: true }), {
-    headers: { 'Content-Type': 'application/json' },
-  });
+  if (!result) {
+    console.error('Realtime broadcast timed out');
+    return new Response('timeout', { status: 500 });
+  }
+
+  const { error } = result;
+  if (error) {
+    console.error(error);
+    return new Response(error.message, { status: 500 });
+  }
+
+  return new Response('ok', { status: 200 });
 });


### PR DESCRIPTION
## Summary
- switch realtime-broadcast function to use realtime channel API
- handle errors returned by `channel.send`
- abort send if no response within 5 seconds

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: many TS errors)*