### PR TITLE
Update get-flame-status lint and calls

### DIFF
--- a/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
+++ b/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
@@ -85,7 +85,7 @@ const buildFlameStatusQueryOpts = (uid: string) => ({
         urlParams: {
           quest_id: FIRST_FLAME_RITUAL_SLUG,
           user_id: uid,
-          day_number: 1,
+          flameSpirit: 'ember',
         },
       },
     );

--- a/src/lib/api/quests.ts
+++ b/src/lib/api/quests.ts
@@ -578,11 +578,11 @@ export async function fetchFlameStatus(): Promise<FlameStatusPayload | { data: n
   }
   const user_id = user.id;
   const quest_id = FIRST_FLAME_QUEST_ID;
-  const day_number = 1;
+  const flameSpirit = 'ember';
 
   const rawServerData = await invoke<unknown>('get-flame-status', {
     method: 'GET',
-    urlParams: { quest_id, user_id, day_number },
+    urlParams: { quest_id, user_id, flameSpirit },
   });
 
   if (rawServerData === null) {

--- a/src/tests/get-flame-status-lint.spec.ts
+++ b/src/tests/get-flame-status-lint.spec.ts
@@ -18,7 +18,7 @@ function walk(dir: string): string[] {
 }
 
 describe('get-flame-status call lint', () => {
-  it('ensures quest_id, user_id and day_number are present', () => {
+  it('ensures quest_id, user_id and flameSpirit are present', () => {
     const files = walk(SRC_DIR);
     const violations: string[] = [];
     const search = "functions.invoke('get-flame-status'";
@@ -29,7 +29,7 @@ describe('get-flame-status call lint', () => {
       while (idx !== -1) {
         const end = content.indexOf(')', idx);
         const snippet = end !== -1 ? content.slice(idx, end + 1) : content.slice(idx);
-        if (!snippet.includes('quest_id') || !snippet.includes('user_id') || !snippet.includes('day_number')) {
+        if (!snippet.includes('quest_id') || !snippet.includes('user_id') || !snippet.includes('flameSpirit')) {
           violations.push(`${file}: ${snippet.replace(/\s+/g, ' ').trim()}`);
         }
         idx = content.indexOf(search, idx + search.length);


### PR DESCRIPTION
## Summary
- update lint test to check new `flameSpirit` parameter
- update get-flame-status calls to use `flameSpirit` query param

## Testing
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*