### PR TITLE
Add TODO for missing CORS in realtime-broadcast

### DIFF
--- a/supabase/functions/realtime-broadcast/index.ts
+++ b/supabase/functions/realtime-broadcast/index.ts
@@ -8,6 +8,7 @@ const sb = createClient(
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
 );
 
+// TODO: handle CORS headers and respond to OPTIONS preflight
 Deno.serve(async (req) => {
   const { channel: channelName, event, payload } = await req.json();
 


### PR DESCRIPTION
## Summary
- document that realtime-broadcast lacks CORS/OPTIONS handling

## Testing
- `npm run lint` *(fails: `next` not found)*