### PR TITLE
Implement flame status loader

### DIFF
--- a/supabase/functions/get-flame-status/index.ts
+++ b/supabase/functions/get-flame-status/index.ts
@@ -1,6 +1,18 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 import { corsHeaders } from "../_shared/cors.ts";
+import {
+  FIRST_FLAME_QUEST_ID,
+  type RitualDayNumber,
+} from "../_shared/5dayquest/FirstFlame.ts";
+import { loadValidateAndCacheDayDef } from "../_shared/5dayquest/flame-data-loader.ts";
+import { getOrCreateFirstFlameProgress } from "../_shared/db/firstFlame.ts";
+
+const FN = "get-flame-status";
+const SB_URL = Deno.env.get("SUPABASE_URL");
+const SB_ANON = Deno.env.get("SUPABASE_ANON_KEY");
+const SB_SVC = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {
@@ -9,25 +21,47 @@ const json = (data: unknown, status = 200): Response =>
   });
 
 Deno.serve(async (req) => {
-  const headersLog = Object.fromEntries(req.headers.entries());
-  const bodyText = await req.text();
-  console.log("[get-flame-status] incoming", { headers: headersLog, bodyText });
+  if (req.method === "OPTIONS") return json({ ok: true });
+  if (req.method !== "POST" && req.method !== "GET")
+    return json({ error: "METHOD_NOT_ALLOWED" }, 405);
 
-  if (req.method === "OPTIONS")
-    return new Response("ok", { headers: corsHeaders });
-
-  if (req.method !== "POST") return json({ error: "Method Not Allowed" }, 405);
+  const authHdr = req.headers.get("Authorization") ?? "";
+  if (!authHdr.startsWith("Bearer ")) return json({ error: "AUTH" }, 401);
 
   try {
-    const payload = bodyText ? JSON.parse(bodyText) : {};
-    const flameSpirit = payload.flameSpirit;
+    const sbUser = createClient(SB_URL!, SB_ANON!, {
+      global: { headers: { Authorization: authHdr } },
+      auth: { persistSession: false },
+      db: { schema: "ritual" },
+    });
+    const sbAdmin = createClient(SB_URL!, SB_SVC!, {
+      auth: { persistSession: false },
+      db: { schema: "ritual" },
+    });
 
-    if (!flameSpirit) return json({ error: "Missing flameSpirit" }, 400);
+    const { data: { user }, error: authErr } = await sbUser.auth.getUser();
+    if (authErr || !user?.id) return json({ error: "AUTH" }, 401);
 
-    console.log("[get-flame-status] Resolved OK");
-    return json({ flameStatus: "blazing" });
+    await getOrCreateFirstFlameProgress(sbAdmin, user.id, FIRST_FLAME_QUEST_ID);
+
+    const { data: progress, error: pe } = await sbUser
+      .from("flame_progress")
+      .select("current_day_target, is_quest_complete, last_imprint_at, updated_at")
+      .eq("quest_id", FIRST_FLAME_QUEST_ID)
+      .maybeSingle();
+    if (pe) throw pe;
+
+    const overallProgress = progress ?? null;
+    const day = (overallProgress?.current_day_target ?? 1) as RitualDayNumber;
+    const dayDefinition = await loadValidateAndCacheDayDef(day);
+
+    return json({
+      dataVersion: Date.now(),
+      overallProgress,
+      dayDefinition,
+    });
   } catch (err) {
-    console.error("[get-flame-status] parse error", err);
-    return json({ error: "Invalid JSON" }, 400);
+    console.error(`[${FN}] error`, err);
+    return json({ error: "SERVER_ERROR" }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- use Supabase admin/user clients in `get-flame-status`
- ensure progress row via `getOrCreateFirstFlameProgress`
- load day definition with `loadValidateAndCacheDayDef`
- always send CORS-aware JSON responses

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx vitest run` *(fails: EHOSTUNREACH – cannot reach npm registry)*