### PR TITLE
Add insertDayOneMessages to worker

### DIFF
--- a/temporal-worker/src/activities/modal.ts
+++ b/temporal-worker/src/activities/modal.ts
@@ -18,6 +18,7 @@ function requireEnv(key: string): string {
 /*────────────────────  Mandatory configuration  ─────────────────────*/
 const MODAL_KICK_URL   = requireEnv('MODAL_KICK_URL');              // string
 const SUPABASE_RPC_URL = requireEnv('SUPABASE_RPC_BROADCAST_URL');  // string
+const SUPABASE_INSERT_DAY1_URL = requireEnv('SUPABASE_RPC_INSERT_DAY1_URL');
 
 /*────────────────────  Shared Axios client  ─────────────────────────*/
 const http = axios.create({
@@ -39,6 +40,23 @@ export async function ensureFlameState(userId: string): Promise<void> {
     const e = err as AxiosError;
     throw new Error(
       `[ensureFlameState] Modal request failed – ${e.message} ` +
+        `(status ${e.response?.status ?? 'n/a'})`,
+    );
+  }
+}
+
+/**
+ * insertDayOneMessages
+ * --------------------------------
+ * Inserts canned Day-1 system & prompt messages for the user.
+ */
+export async function insertDayOneMessages(userId: string): Promise<void> {
+  try {
+    await http.post(SUPABASE_INSERT_DAY1_URL, { user_id: userId });
+  } catch (err) {
+    const e = err as AxiosError;
+    throw new Error(
+      `[insertDayOneMessages] Supabase Edge Function failed – ${e.message} ` +
         `(status ${e.response?.status ?? 'n/a'})`,
     );
   }

--- a/temporal-worker/src/workflows/seedFirstFlame.ts
+++ b/temporal-worker/src/workflows/seedFirstFlame.ts
@@ -13,11 +13,12 @@ export const seedFirstFlameSignal = wf.defineSignal<[SeedFirstFlameInput]>(
 );
 
 /** -------- Activity proxies --------
- *  • `ensureFlameState` – creates / validates DB rows in Supabase
- *  • `broadcastReady`   – sends realtime ready event
+ *  • `ensureFlameState`    – creates / validates DB rows in Supabase
+ *  • `insertDayOneMessages` – seeds Day‑1 prompt messages
+ *  • `broadcastReady`      – sends realtime ready event
  *  Edit the timeout / retry settings per Activity as you refine them.
  */
-const { ensureFlameState, broadcastReady } = wf.proxyActivities<
+const { ensureFlameState, insertDayOneMessages, broadcastReady } = wf.proxyActivities<
   typeof act
 >({
   startToCloseTimeout: '1 minute',
@@ -31,6 +32,9 @@ export async function seedFirstFlame(
   // 1) Guarantee quest-state exists
   await ensureFlameState(input.userId);
 
-  // 2) Tell the front-end it can refetch
+  // 2) Insert Day‑1 system + prompt messages
+  await insertDayOneMessages(input.userId);
+
+  // 3) Tell the front-end it can refetch
   await broadcastReady(input.userId);
 }


### PR DESCRIPTION
## Summary
- add `insertDayOneMessages` activity for seeding day‑1 chat
- call it from `seedFirstFlame` workflow before broadcasting readiness

## Testing
- `pnpm run lint` *(fails: next not found)*
- `pnpm run typecheck` *(fails: node_modules missing)*