### PR TITLE
Ensure flame status check resolves before redirect

### DIFF
--- a/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
+++ b/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
@@ -215,7 +215,7 @@ export const useUnifiedChatPanelData = ({
 
   const selectQuestSafely = useCallback(
     // Function signature and logic changed by diff
-    (questId: string | null) => {
+    async (questId: string | null): Promise<void> => {
       if (!questId) {
         setActiveQuestId(null);
         return;
@@ -229,11 +229,12 @@ export const useUnifiedChatPanelData = ({
       startTransition(() => {
         setActiveQuestId(questId); // Was selectQuest(id)
         announceToSR(`Selected ${questToSelect.name}.`); // Was quest.name
-        if (questToSelect.isFirstFlameRitual) {
-          // Was quest.isFirstFlameRitual
-          void maybeRedirectToRitualDayOne();
-        }
       });
+
+      if (questToSelect.isFirstFlameRitual) {
+        // Was quest.isFirstFlameRitual
+        await maybeRedirectToRitualDayOne();
+      }
     },
     [
       questsArray,
@@ -299,7 +300,7 @@ export const useUnifiedChatPanelData = ({
 
     const flameQuest = questsArray.find((q) => q.isFirstFlameRitual);
     if (flameQuest && !hasDoneInitialAutoSelect.current) {
-      selectQuestSafely(flameQuest.id);
+      void selectQuestSafely(flameQuest.id);
       hasDoneInitialAutoSelect.current = true;
     }
 
@@ -324,7 +325,7 @@ export const useUnifiedChatPanelData = ({
       questsArray.find((q) => q.isFirstFlameRitual) ||
       questsArray[0];
 
-    if (target) selectQuestSafely(target.id);
+    if (target) void selectQuestSafely(target.id);
     hasDoneInitialAutoSelect.current = true;
 
     // Check query state before prefetching to avoid redundant calls - Added by diff


### PR DESCRIPTION
## Summary
- make `selectQuestSafely` asynchronous
- wait on `maybeRedirectToRitualDayOne` when selecting the First‑Flame quest
- call helper with `void` to avoid floating Promise

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm typecheck` *(fails: missing node modules)*