### PR TITLE
Fix UseQueryOptions generic syntax

### DIFF
--- a/src/lib/api/quests.ts
+++ b/src/lib/api/quests.ts
@@ -769,7 +769,7 @@ export function buildFlameStatusQueryOpts(
   | FunctionsRelayError
   | FunctionsFetchError
   | NetworkError
-  | Error
+  | Error,
   FlameStatusResponse,
   FlameStatusQueryKey
 > {


### PR DESCRIPTION
## Summary
- fix type definition for `buildFlameStatusQueryOpts`

## Testing
- `npm run typecheck` *(fails: missing dependencies)*
- `npm run lint` *(fails: `next` not found)*