### PR TITLE
Fix quest ID retrieval for First Flame

### DIFF
--- a/supabase/functions/_shared/db/firstFlame.ts
+++ b/supabase/functions/_shared/db/firstFlame.ts
@@ -128,3 +128,21 @@ export async function getOrCreateFirstFlameProgress(
     throw error;
   }
 }
+
+/**
+ * ensureFirstFlameQuest
+ * -----------------------------------------------------
+ * Thin wrapper used by Edge Functions to guarantee the
+ * First Flame quest exists and return only its id.
+ */
+export async function ensureFirstFlameQuest(
+  admin: SupabaseClient,
+): Promise<{ id: string }> {
+  const { id } = await getOrCreateFirstFlame(admin, {
+    title: 'First Flame Ritual',
+    type: 'ritual',
+    realm: 'first_flame',
+    is_pinned: true,
+  });
+  return { id };
+}


### PR DESCRIPTION
## Summary
- add `ensureFirstFlameQuest` helper
- use new helper in list-quests function

## Testing
- `npm run typecheck` *(fails: NotificationItem.ts errors)*