### PR TITLE
Fix flame status quest id handling

### DIFF
--- a/supabase/functions/_shared/db/firstFlame.ts
+++ b/supabase/functions/_shared/db/firstFlame.ts
@@ -100,6 +100,23 @@ export async function getOrCreateFirstFlame(
 }
 
 /**
+ * ensureFirstFlameQuest
+ * -----------------------------------------------------
+ * Convenience wrapper returning only the quest id.
+ */
+export async function ensureFirstFlameQuest(
+  admin: SupabaseClient,
+): Promise<{ id: string }> {
+  const quest = await getOrCreateFirstFlame(admin, {
+    title: 'First Flame Ritual',
+    type: 'ritual',
+    realm: 'first_flame',
+    is_pinned: true,
+  });
+  return { id: quest.id };
+}
+
+/**
  * getOrCreateFirstFlameProgress
  * -----------------------------------------------------
  * Ensure a flame_progress row exists for the given user.


### PR DESCRIPTION
## Summary
- add `ensureFirstFlameQuest` helper
- use questId from DB in `get-flame-status`

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH)*