### PR TITLE
Fix questId handling in flame status API

### DIFF
--- a/src/app/ritual/[day]/page.tsx
+++ b/src/app/ritual/[day]/page.tsx
@@ -4,6 +4,7 @@ import { ViewTransition } from 'react'; // React 19
 import { useQuery } from '@tanstack/react-query';
 import { FlameStatusResponse } from '@flame'; // Changed from FlameStatusPayload
 import { fetchFlameStatus } from '@/lib/api/quests';
+import { FIRST_FLAME_QUEST_ID } from '@flame';
 
 // Assuming FullPageSpinner, ErrorState, and DayLayout are defined elsewhere
 // For completeness, let's add dummy versions if they weren't part of the original snippet.
@@ -20,8 +21,8 @@ const DayLayout = ({ def, imprints }: { def: any; imprints: any }) => (
 
 export default function RitualDay({ params:{ day } }: { params: { day: string } }) { // Added type for params
   const { data, isPending, error } = useQuery<FlameStatusResponse>({ // Explicitly typed useQuery
-    queryKey: ['flame-status'],
-    queryFn : fetchFlameStatus,
+    queryKey: ['flame-status', FIRST_FLAME_QUEST_ID],
+    queryFn : () => fetchFlameStatus(FIRST_FLAME_QUEST_ID),
     staleTime: 0,
     placeholderData: previous => previous,
   });

--- a/src/hooks/useFlameStatus.ts
+++ b/src/hooks/useFlameStatus.ts
@@ -21,6 +21,7 @@ import {
 import { useEffect } from 'react';
 // Query helpers for First Flame status
 import { fetchFlameStatus, FLAME_STATUS_QUERY_KEY } from '@/lib/api/quests';
+import { FIRST_FLAME_QUEST_ID } from '@flame';
 import { useBoundStore } from '@/lib/state/store';
 // FlameStatusResponse should contain `dataVersion: number` (or similar) for version comparison.
 import type { FlameStatusResponse } from '@flame';
@@ -48,7 +49,9 @@ const flameStatusRetryDelay = (attemptIndex: number): number => {
   return Math.min(1000 * 2 ** attemptIndex, 20000);
 };
 
-export function useFlameStatus(): UseQueryResult<FlameStatusResponse, unknown> {
+export function useFlameStatus(
+  questId: string = FIRST_FLAME_QUEST_ID,
+): UseQueryResult<FlameStatusResponse, unknown> {
   const queryClient = useQueryClient();
   // Stable selectors for Zustand actions and version, preventing re-subscriptions.
   const hydrate = useBoundStore((s) => s.firstFlame._hydrateFromServer);
@@ -72,7 +75,7 @@ export function useFlameStatus(): UseQueryResult<FlameStatusResponse, unknown> {
     typeof FLAME_STATUS_QUERY_KEY // TQueryKey: strictly typed using the constant
   >({
     queryKey: FLAME_STATUS_QUERY_KEY, // Use the exported constant
-    queryFn: fetchFlameStatus,
+    queryFn: () => fetchFlameStatus(questId),
     staleTime: 0, // Ritual UX: Data is always considered stale, ensuring refetch on mount.
     refetchOnWindowFocus: true, // Ritual UX: Ensures progress updates if user worked in another tab.
     placeholderData: (previous) => previous, // UX: TanStack v5 pattern. Keeps old data visible, no UI flash.

--- a/src/lib/state/slices/firstFlameSlice.ts
+++ b/src/lib/state/slices/firstFlameSlice.ts
@@ -339,11 +339,11 @@ export const createFirstFlameSlice: StateCreator<
       Math.min(2 ** attempt * 1000 + Math.random() * 200, 30_000);
 
     let attempt = 0;
-    let status: any = await flameApi.fetchFlameStatus();
+    let status: any = await flameApi.fetchFlameStatus(FIRST_FLAME_QUEST_ID);
     while (status?.processing && attempt < 3) {
       await new Promise(res => setTimeout(res, delayFor(attempt)));
       attempt += 1;
-      status = await flameApi.fetchFlameStatus();
+      status = await flameApi.fetchFlameStatus(FIRST_FLAME_QUEST_ID);
     }
 
     if (!status?.processing) {


### PR DESCRIPTION
## Summary
- accept questId in `fetchFlameStatus`
- warn when a slug-like questId is passed
- update React Query helpers to forward questId
- pass questId from First Flame slice and ritual pages
- expose helper options for custom quest IDs

## Testing
- `pnpm typecheck` *(fails: node_modules missing)*
- `pnpm lint` *(fails: next not found)*