### PR TITLE
Add idempotency test for First Flame quest

### DIFF
--- a/src/tests/ensureFirstFlameQuest.test.ts
+++ b/src/tests/ensureFirstFlameQuest.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getOrCreateFirstFlame } from '@supabase-shared/db/firstFlame.ts';
+
+function createMockSupabase() {
+  let quest: any = null;
+  const insertMock = vi.fn();
+  return {
+    insertMock,
+    from() {
+      const query: any = {};
+      query.select = () => query;
+      query.eq = () => query;
+      query.maybeSingle = async () => ({ data: quest, error: null });
+      query.insert = (payload: any) => {
+        insertMock();
+        if (!quest) {
+          quest = {
+            id: '11111111-1111-1111-1111-111111111111',
+            slug: payload.slug,
+            title: payload.title,
+            type: payload.type,
+          };
+        }
+        return query;
+      };
+      query.single = async () => ({ data: quest, error: null });
+      return query;
+    },
+  };
+}
+
+describe('getOrCreateFirstFlame', () => {
+  it('returns same quest id when called twice', async () => {
+    const sb = createMockSupabase();
+    const first = await getOrCreateFirstFlame(sb as any);
+    const second = await getOrCreateFirstFlame(sb as any);
+    expect(first.id).toBe(second.id);
+    expect(sb.insertMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    include: ['src/tests/**/*.{test,spec}.{ts,tsx}'],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@supabase-shared': resolve(__dirname, 'supabase/functions/_shared'),
+      '@ritual': resolve(__dirname, 'supabase/functions/_shared/5dayquest'),
+      '@flame': resolve(__dirname, 'src/lib/shared/firstFlame.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- test `getOrCreateFirstFlame` helper with a mocked Supabase client
- add vitest config so tests in `src/tests` are discovered

## Testing
- `npx vitest run` *(fails: package not installed)*