### PR TITLE
Add manual migration for flame quest ID

### DIFF
--- a/docs/deployment-notes.md
+++ b/docs/deployment-notes.md
@@ -1,0 +1,11 @@
+# Deployment Notes
+
+## Manual SQL Migrations
+
+Run `scripts/migrate-flame-quest-id.sql` manually before enabling new FK constraints:
+
+```bash
+psql "$DATABASE_URL" -f scripts/migrate-flame-quest-id.sql
+```
+
+This converts legacy quest slug references to UUIDs in `ritual.flame_progress`.

--- a/scripts/migrate-flame-quest-id.sql
+++ b/scripts/migrate-flame-quest-id.sql
@@ -1,0 +1,6 @@
+-- Convert legacy slug references to UUID
+UPDATE ritual.flame_progress
+SET quest_id = (SELECT id FROM ritual.quests WHERE slug='first-flame-ritual')
+WHERE quest_id = 'first-flame-ritual';
+
+-- TODO: add FOREIGN KEY constraint once data is clean


### PR DESCRIPTION
## Summary
- add SQL script to convert legacy `quest_id` slug to UUID
- note manual execution in deployment notes

## Testing
- `pnpm run lint` *(fails: next not found)*
- `pnpm run typecheck` *(fails: dependencies missing)*