### PR TITLE
Fix FIRST_FLAME_QUEST_ID compatibility

### DIFF
--- a/src/lib/shared/firstFlame.ts
+++ b/src/lib/shared/firstFlame.ts
@@ -6,6 +6,13 @@ import type { ReadonlyDeep } from 'type-fest';
 export const FIRST_FLAME_SLUG       = 'first-flame-ritual' as const;
 export const FIRST_FLAME_TOTAL_DAYS = 5 as const;
 
+/** ------------------------------------------------------------------ *
+ *  TEMP-shim: keep legacy imports compiling.                          *
+ *  Remove once all call-sites use FIRST_FLAME_SLUG directly.          *
+ *  ------------------------------------------------------------------ */
+/** @deprecated – use FIRST_FLAME_SLUG instead */
+export const FIRST_FLAME_QUEST_ID = FIRST_FLAME_SLUG;
+
 /*--------------------------------------------------------------*
  | 2 · Ritual-stage enums re-exported for convenience            |
  *   (path alias “@ritual/…” is wired in tsconfig + webpack)     |


### PR DESCRIPTION
## Summary
- add deprecated `FIRST_FLAME_QUEST_ID` alias back into `firstFlame.ts`
- keep alias mapped via `@flame` path

## Testing
- `pnpm typecheck` *(fails: missing dependencies)*
- `pnpm dev` *(fails: `next` not found)*
- `pnpm test -t flame` *(fails: invalid Jest args)*