### PR TITLE
Add FIRST_FLAME_QUERY_KEY helper

### DIFF
--- a/src/app/ritual/[day]/page.tsx
+++ b/src/app/ritual/[day]/page.tsx
@@ -1,10 +1,13 @@
 // app/ritual/[day]/page.tsx
-import { notFound, redirect } from 'next/navigation';
-import { ViewTransition } from 'react'; // React 19
-import { useQuery } from '@tanstack/react-query';
-import { FlameStatusResponse } from '@flame'; // Changed from FlameStatusPayload
-import { fetchFlameStatus } from '@/lib/api/quests';
-import { FIRST_FLAME_QUEST_ID } from '@flame';
+import { notFound, redirect } from "next/navigation";
+import { ViewTransition } from "react"; // React 19
+import { useQuery } from "@tanstack/react-query";
+import {
+  FlameStatusResponse,
+  FIRST_FLAME_QUERY_KEY,
+  FIRST_FLAME_QUEST_ID,
+} from "@flame";
+import { fetchFlameStatus } from "@/lib/api/quests";
 
 // Assuming FullPageSpinner, ErrorState, and DayLayout are defined elsewhere
 // For completeness, let's add dummy versions if they weren't part of the original snippet.
@@ -18,17 +21,22 @@ const DayLayout = ({ def, imprints }: { def: any; imprints: any }) => (
   </div>
 );
 
-
-export default function RitualDay({ params:{ day } }: { params: { day: string } }) { // Added type for params
-  const { data, isPending, error } = useQuery<FlameStatusResponse>({ // Explicitly typed useQuery
-    queryKey: ['flame-status', FIRST_FLAME_QUEST_ID],
-    queryFn : () => fetchFlameStatus(FIRST_FLAME_QUEST_ID),
+export default function RitualDay({
+  params: { day },
+}: {
+  params: { day: string };
+}) {
+  // Added type for params
+  const { data, isPending, error } = useQuery<FlameStatusResponse>({
+    // Explicitly typed useQuery
+    queryKey: FIRST_FLAME_QUERY_KEY,
+    queryFn: () => fetchFlameStatus(),
     staleTime: 0,
-    placeholderData: previous => previous,
+    placeholderData: (previous) => previous,
   });
 
-  if (isPending) return <FullPageSpinner/>;
-  if (error)    return <ErrorState/>;
+  if (isPending) return <FullPageSpinner />;
+  if (error) return <ErrorState />;
 
   const target = data?.overallProgress?.current_day_target;
   // redirect forward/back if user is on the wrong day
@@ -46,7 +54,7 @@ export default function RitualDay({ params:{ day } }: { params: { day: string } 
 
   return (
     <ViewTransition name="ff-day-shell">
-      <DayLayout def={def} imprints={data.imprints}/>
+      <DayLayout def={def} imprints={data.imprints} />
     </ViewTransition>
   );
 }

--- a/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
+++ b/src/features/hub/components/leftpanel/useUnifiedChatPanelData.ts
@@ -36,6 +36,7 @@ import {
 import { announceToSR } from "@/lib/accessibilityUtils";
 import { seedFirstFlame } from "@/lib/temporal_client"; // 🚩 Temporal client wrapper
 import { fetchQuestList } from "@/lib/api/quests"; // Added by diff
+import { FIRST_FLAME_QUERY_KEY } from "@flame";
 
 /* ---------- Types ---------- */
 export interface QuestPayloadFromServer {
@@ -64,10 +65,8 @@ export type QuestForListItemAugmented = Quest;
 /* ---------- Helpers ---------- */
 class SilentError extends Error {}
 // keyListQuests removed as per diff implication (usage replaced by QUESTS_QUERY_KEY)
-const keyFlameStatus = (uid?: string): QueryKey => [
-  "flame-status",
-  uid ?? "anon",
-];
+const keyFlameStatus = (uid?: string): QueryKey =>
+  uid ? [...FIRST_FLAME_QUERY_KEY, uid] : FIRST_FLAME_QUERY_KEY;
 
 const mapQuest = (row: QuestPayloadFromServer): Quest | null => {
   if (!row.id || !row.name || !row.slug) return null;

--- a/src/hooks/useFlameStatus.ts
+++ b/src/hooks/useFlameStatus.ts
@@ -16,30 +16,35 @@
  */
 
 import {
-  useQuery, useQueryClient, type UseQueryResult,
-} from '@tanstack/react-query';
-import { useEffect } from 'react';
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { useEffect } from "react";
 // Query helpers for First Flame status
-import { fetchFlameStatus, FLAME_STATUS_QUERY_KEY } from '@/lib/api/quests';
-import { FIRST_FLAME_QUEST_ID } from '@flame';
-import { useBoundStore } from '@/lib/state/store';
+import { fetchFlameStatus } from "@/lib/api/quests";
+import { FIRST_FLAME_QUERY_KEY, FIRST_FLAME_QUEST_ID } from "@flame";
+import { useBoundStore } from "@/lib/state/store";
 // FlameStatusResponse should contain `dataVersion: number` (or similar) for version comparison.
-import type { FlameStatusResponse } from '@flame';
+import type { FlameStatusResponse } from "@flame";
 
 // Type for errors passed to the Zustand slice's setError action.
 // This allows UI to branch on error types (e.g., show specific messages for RLS).
 export type SliceError =
-  | { type: 'supabase'; status: number; message: string }
-  | { type: 'network'; message: string }
-  | { type: 'unknown'; message: string };
+  | { type: "supabase"; status: number; message: string }
+  | { type: "network"; message: string }
+  | { type: "unknown"; message: string };
 
 // Type guard for Supabase-like errors (can be refined based on actual error structure)
 // This helps ensure `err.status` and `err.message` exist before access.
-function isSupabaseRpcError(err: unknown): err is { status: number; message: string } {
+function isSupabaseRpcError(
+  err: unknown,
+): err is { status: number; message: string } {
   return (
-    typeof err === 'object' && err !== null &&
-    typeof (err as { status?: unknown }).status === 'number' &&
-    typeof (err as { message?: unknown }).message === 'string'
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { status?: unknown }).status === "number" &&
+    typeof (err as { message?: unknown }).message === "string"
   );
 }
 
@@ -62,46 +67,61 @@ export function useFlameStatus(
   useEffect(() => {
     const handleOnline = () => {
       // Use the exported constant for the query key
-      queryClient.invalidateQueries({ queryKey: FLAME_STATUS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: FIRST_FLAME_QUERY_KEY });
     };
-    window.addEventListener('online', handleOnline);
-    return () => window.removeEventListener('online', handleOnline);
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
   }, [queryClient]); // queryClient is stable, effect runs once per component instance.
 
   return useQuery<
     FlameStatusResponse, // TQueryFnData: type returned by queryFn
-    unknown,             // TError: type for errors
+    unknown, // TError: type for errors
     FlameStatusResponse, // TData: type of data delivered to components
-    typeof FLAME_STATUS_QUERY_KEY // TQueryKey: strictly typed using the constant
+    typeof FIRST_FLAME_QUERY_KEY
   >({
-    queryKey: FLAME_STATUS_QUERY_KEY, // Use the exported constant
+    queryKey: FIRST_FLAME_QUERY_KEY,
     queryFn: () => fetchFlameStatus(questId),
     staleTime: 0, // Ritual UX: Data is always considered stale, ensuring refetch on mount.
     refetchOnWindowFocus: true, // Ritual UX: Ensures progress updates if user worked in another tab.
     placeholderData: (previous) => previous, // UX: TanStack v5 pattern. Keeps old data visible, no UI flash.
     // SSR/Offline: Skip fetch if restoring from SSR hydration or if offline.
-    enabled: !queryClient.isRestoring && (typeof navigator !== 'undefined' ? navigator.onLine : true),
+    enabled:
+      !queryClient.isRestoring &&
+      (typeof navigator !== "undefined" ? navigator.onLine : true),
     retryDelay: flameStatusRetryDelay,
     // Default retry for React Query is 3 times for queryFn failures.
-    refetchInterval: (data) => (data && (data as any).processing === true ? 2000 : false),
+    refetchInterval: (data) =>
+      data && (data as any).processing === true ? 2000 : false,
 
     onSuccess: (data: FlameStatusResponse) => {
       // Silent Hydration: Update slice only if fetched data is newer.
       // Use `data.dataVersion` (or the actual version field name from FlameStatusResponse).
       // Guard version check: `sliceVersion ?? 0` handles initial undefined/0 state.
       // Assumes FlameStatusResponse has a `dataVersion: number` field.
-      if (typeof data.dataVersion === 'number' && (sliceVersion ?? 0) < data.dataVersion) {
+      if (
+        typeof data.dataVersion === "number" &&
+        (sliceVersion ?? 0) < data.dataVersion
+      ) {
         hydrate(data);
       }
     },
-    onError: (err: unknown) => { // Error Bubbling: Surface typed errors to Zustand slice.
+    onError: (err: unknown) => {
+      // Error Bubbling: Surface typed errors to Zustand slice.
 
       if (isSupabaseRpcError(err)) {
-        setError({ type: 'supabase', status: err.status, message: err.message });
-      } else if (err instanceof TypeError) { // TypeError often indicates network issues like "Failed to fetch".
-        setError({ type: 'network', message: err.message });
+        setError({
+          type: "supabase",
+          status: err.status,
+          message: err.message,
+        });
+      } else if (err instanceof TypeError) {
+        // TypeError often indicates network issues like "Failed to fetch".
+        setError({ type: "network", message: err.message });
       } else {
-        setError({ type: 'unknown', message: err instanceof Error ? err.message : String(err) });
+        setError({
+          type: "unknown",
+          message: err instanceof Error ? err.message : String(err),
+        });
       }
     },
   });

--- a/src/lib/shared/firstFlame.ts
+++ b/src/lib/shared/firstFlame.ts
@@ -1,10 +1,16 @@
-import type { ReadonlyDeep } from 'type-fest';
+import type { ReadonlyDeep } from "type-fest";
 
 /*--------------------------------------------------------------*
  | 1 · Public constants                                          |
  *--------------------------------------------------------------*/
-export const FIRST_FLAME_SLUG       = 'first-flame-ritual' as const;
+export const FIRST_FLAME_SLUG = "first-flame-ritual" as const;
 export const FIRST_FLAME_TOTAL_DAYS = 5 as const;
+export const FIRST_FLAME_QUERY_KEY = [
+  "flame-status",
+  FIRST_FLAME_SLUG,
+] as const;
+export const isFirstFlame = (q: { slug?: string }): boolean =>
+  q.slug === FIRST_FLAME_SLUG;
 
 /** ------------------------------------------------------------------ *
  *  TEMP-shim: keep legacy imports compiling.                          *
@@ -25,18 +31,15 @@ export {
   STAGE_SIGNATURE,
   RITUAL_STAGES_LOOKUP,
   DAY_TO_RITUAL_STAGE_MAP,
-}                             from '@ritual/ritual.constants';
-export type {
-  RitualStage,
-  RitualDayNumber,
-}                             from '@ritual/ritual.constants';
+} from "@ritual/ritual.constants";
+export type { RitualStage, RitualDayNumber } from "@ritual/ritual.constants";
 
 /*--------------------------------------------------------------*
  | 3 · Day-1 JSON (imported via `resolveJsonModule: true`)      |
  *   – This gives us full IntelliSense & keeps source-of-truth   |
  *     in the Supabase shared folder.                           |
  *--------------------------------------------------------------*/
-import day1Json from '@ritual/day-1.json';          // <- alias in ts/webpack
+import day1Json from "@ritual/day-1.json"; // <- alias in ts/webpack
 
 export type FlameDayDefinition = ReadonlyDeep<typeof day1Json>;
 
@@ -47,13 +50,13 @@ export const DAY1_FLAME_DEFINITION: FlameDayDefinition = day1Json;
  | 4 · Minimal client-side payload types                         |
  *--------------------------------------------------------------*/
 export type FlameProgressData = ReadonlyDeep<{
-  current_day_target: number;     // 1-5
-  is_quest_complete:  boolean;
+  current_day_target: number; // 1-5
+  is_quest_complete: boolean;
 }>;
 
 export type FlameStatusPayload = ReadonlyDeep<{
   overallProgress: FlameProgressData | null;
-  dayDefinition:   FlameDayDefinition | null;
+  dayDefinition: FlameDayDefinition | null;
 }>;
 
 export type FlameStatusResponse =


### PR DESCRIPTION
## Summary
- export `FIRST_FLAME_QUERY_KEY` and `isFirstFlame`
- use them when building query options
- update ritual day page and hooks to use the constant
- update unified chat panel utilities

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*
- `npm run lint` *(fails: next not found)*