### PR TITLE
Add flame types barrel and update imports

### DIFF
--- a/src/app/ritual/[day]/page.tsx
+++ b/src/app/ritual/[day]/page.tsx
@@ -2,7 +2,7 @@
 import { notFound, redirect } from 'next/navigation';
 import { ViewTransition } from 'react'; // React 19
 import { useQuery } from '@tanstack/react-query';
-import { FlameStatusResponse } from '@flame'; // Changed from FlameStatusPayload
+import type { FlameStatusResponse } from '@/types/flame';
 import { fetchFlameStatus } from '@/lib/api/quests';
 import { FIRST_FLAME_QUEST_ID } from '@flame';
 

--- a/src/features/hub/components/ActiveConversationPanel.tsx
+++ b/src/features/hub/components/ActiveConversationPanel.tsx
@@ -33,7 +33,8 @@ import { useContextStore } from '@/lib/state/slices/contextSlice';
 
 import type { Quest } from '@/types/quest';
 import type { ActiveConversationPanelProps } from './ActiveConversationPanel.types';
-import { FIRST_FLAME_SLUG, type FlameStatusResponse } from '@flame'; // Changed from FlameStatusPayload
+import { FIRST_FLAME_SLUG } from '@flame';
+import type { FlameStatusResponse } from '@/types/flame';
 
 import { fetchFlameStatus, invalidateFlameStatus } from '@/lib/api/quests';
 import { getPanelMeta } from '@/lib/core/panelMetaRegistry';

--- a/src/hooks/useFlameStatus.ts
+++ b/src/hooks/useFlameStatus.ts
@@ -24,7 +24,7 @@ import { fetchFlameStatus, FLAME_STATUS_QUERY_KEY } from '@/lib/api/quests';
 import { FIRST_FLAME_QUEST_ID } from '@flame';
 import { useBoundStore } from '@/lib/state/store';
 // FlameStatusResponse should contain `dataVersion: number` (or similar) for version comparison.
-import type { FlameStatusResponse } from '@flame';
+import type { FlameStatusResponse } from '@/types/flame';
 
 // Type for errors passed to the Zustand slice's setError action.
 // This allows UI to branch on error types (e.g., show specific messages for RLS).

--- a/src/types/flame/index.ts
+++ b/src/types/flame/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-exported First Flame payload types for shared use across the app.
+ * Keeping these in @/types avoids pulling in the full module when only
+ * the network payload definitions are required.
+ */
+export type {
+  FlameStatusPayload,
+  FlameStatusResponse,
+} from '@flame';


### PR DESCRIPTION
## Summary
- expose `FlameStatusPayload` and `FlameStatusResponse` via new `src/types/flame/index.ts`
- import `FlameStatusResponse` from `@/types/flame` across the app

## Testing
- `pnpm run typecheck` *(fails: Local package.json exists, but node_modules missing)*