### PR TITLE
Fix Temporal worker build errors

### DIFF
--- a/temporal-worker/package.json
+++ b/temporal-worker/package.json
@@ -15,7 +15,8 @@
     "@temporalio/worker": "^1.11.8",
     "@temporalio/workflow": "^1.11.8",
     "axios": "^1.9.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "type-fest": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.18",

--- a/temporal-worker/src/workflows/seedFirstFlame.ts
+++ b/temporal-worker/src/workflows/seedFirstFlame.ts
@@ -1,7 +1,7 @@
 // src/workflows/seedFirstFlame.ts
 import * as wf from '@temporalio/workflow';
 import type * as act from '../activities';         // adjust the path if your activities live elsewhere
-import { FIRST_FLAME_QUEST_ID } from '../../src/lib/shared/firstFlame';
+import { FIRST_FLAME_QUEST_ID } from '../../../src/lib/shared/firstFlame';
 
 /** -------- Types -------- */
 export interface SeedFirstFlameInput {

--- a/temporal-worker/tsconfig.json
+++ b/temporal-worker/tsconfig.json
@@ -26,11 +26,14 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    "module": "Node16",                                  /* Node ESM matching moduleResolution */
+    "rootDir": ".",                                      /* Allow imports from repo root */
     "moduleResolution": "node16",                        /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": "./",                                     /* Resolve paths from the worker folder */
+    "paths": {
+      "@ritual/*": ["../supabase/functions/_shared/5dayquest/*"],
+      "@flame": ["../src/lib/shared/firstFlame.ts"]
+    },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -42,7 +45,7 @@
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 


### PR DESCRIPTION
## Summary
- allow Temporal worker to compile files outside src and use repo aliases
- add `type-fest` dependency for shared types
- point workflow to the correct shared constants file

## Testing
- `pnpm exec tsc`