### PR TITLE
Fix worker bundler alias

### DIFF
--- a/temporal-worker/src/global.d.ts
+++ b/temporal-worker/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '@ritual/*.json' {
+  const value: any;
+  export default value;
+}

--- a/temporal-worker/src/worker.ts
+++ b/temporal-worker/src/worker.ts
@@ -34,6 +34,25 @@ async function main(): Promise<void> {
     taskQueue: TEMPORAL_TASK_QUEUE,
     namespace: TEMPORAL_NAMESPACE,
     connection,                            // may be undefined (local dev) :contentReference[oaicite:1]{index=1}
+
+    /* Fix module-not-found errors for shared quest code */
+    bundlerOptions: {
+      webpackConfigHook: (config) => {
+        config.resolve ??= {};
+        config.resolve.alias = {
+          ...(config.resolve.alias || {}),
+          '@ritual': path.resolve(
+            __dirname,
+            '../../supabase/functions/_shared/5dayquest'
+          ),
+          '@flame': path.resolve(
+            __dirname,
+            '../../src/lib/shared/firstFlame.ts'
+          ),
+        };
+        return config;
+      },
+    },
   });
 
   /* Graceful shutdown — Ctrl-C / docker stop */


### PR DESCRIPTION
## Summary
- ensure Temporal worker bundler resolves @ritual and @flame modules
- declare module for JSON ritual imports

## Testing
- `pnpm test` *(fails: vitest not found)*