### PR TITLE
Fix D-Pad transition listener loop

### DIFF
--- a/src/components/navigation/CompassDPadDesktop.tsx
+++ b/src/components/navigation/CompassDPadDesktop.tsx
@@ -180,12 +180,17 @@ const CompassDPadDesktop: React.FC = () => {
     const [isTransitioning, setIsTransitioning] = useState(false);
     const navRef = useRef<HTMLElement>(null);
 
+    const handleTransitionStart = useCallback(() => {
+        setIsTransitioning(true);
+    }, []);
+
+    const handleTransitionEnd = useCallback(() => {
+        setIsTransitioning(false);
+    }, []);
+
     useEffect(() => {
         const node = navRef.current;
         if (!node) return;
-
-        const handleTransitionStart = () => setIsTransitioning(true);
-        const handleTransitionEnd = () => setIsTransitioning(false);
 
         // Assuming the transition is on 'inset-inline-start'
         node.addEventListener('transitionstart', handleTransitionStart);
@@ -197,7 +202,7 @@ const CompassDPadDesktop: React.FC = () => {
             node.removeEventListener('transitionend', handleTransitionEnd);
             node.removeEventListener('transitioncancel', handleTransitionEnd);
         };
-    }, []); // Run only once
+    }, [handleTransitionEnd, handleTransitionStart]);
 
 
     // --- Render ---


### PR DESCRIPTION
## Summary
- adjust transition event handlers in `CompassDPadDesktop`

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `vitest` not found)*
- `pnpm typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840bc4f8e708322acf4960dd620eb64